### PR TITLE
Removes syntax error in Russian translation

### DIFF
--- a/ru/LC_MESSAGES/messages.po
+++ b/ru/LC_MESSAGES/messages.po
@@ -117,7 +117,7 @@ msgstr[2] ""
 #, python-format
 msgid "%(n)d new item For Sale in your Wantlist"
 msgid_plural "%(n)d new items For Sale in your Wantlist"
-msgstr[0] "%(n)d новых предметов для покупки из вашего списка желаний"
+msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 


### PR DESCRIPTION
From `pybabel`:

```
..
Pushing 'ru' translations (file: i18n/ru/LC_MESSAGES/messages.po)
Error uploading file: There is a syntax error in your file.
Line msgfmt: Line  warning: PO file header fuzzy
                 warning: older versions of msgfmt will give an error on this
Line 120: a format specification for argument 'n' doesn't exist in 'msgstr[1]'
msgfmt: found 2 fatal errors
Skipping 'da_DK' translation (file: i18n/da_DK/LC_MESSAGES/messages.po).
...
```

This message was missing the plural translation.