### PR TITLE
Fix newlines in French translation

### DIFF
--- a/fr/LC_MESSAGES/messages_js.po
+++ b/fr/LC_MESSAGES/messages_js.po
@@ -419,7 +419,7 @@ msgid "Place order"
 msgstr "Confirmer la commande"
 
 msgid "Place order and pay now"
-msgstr "Confirmez la commande et payez maintenant\n"
+msgstr "Confirmez la commande et payez maintenant"
 
 msgid "Placing order..."
 msgstr "Commande en cours de confirmation..."


### PR DESCRIPTION
From `msgfmt`:

```bash
i18n/fr/LC_MESSAGES/messages_js.po:422: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 1 fatal error
```